### PR TITLE
Verify supported content type, don't interfere with (for example) JSON responses

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -19,30 +19,32 @@ App::after(function($request, $response)
 	    {
 	    	$output = $response->getOriginalContent();
 
-	    	$urls = preg_match_all("#\bhttps?://[^\s()<>]+(?:\([\w\d]+\)|[^[:punct:]\s]|/)#", $output, $matches);
+            if (is_string($output) || method_exists($output, '__toString')) {
+                $urls = preg_match_all("#\bhttps?://[^\s()<>]+(?:\([\w\d]+\)|[^[:punct:]\s]|/)#", $output, $matches);
 
-	    	foreach ($matches[0] as $uri)
-	    		foreach (Config::get('simplecdn::rules') as $group)
-	    			if (@$group['enabled'] && preg_match('/\.(' . @$group['pattern'] . ')(?:[\?\#].*)?$/i', $uri, $matchess))
-	    			{
-	    				$config_url = Config::get('simplecdn::url');
-	    				$config_remove = Config::get('simplecdn::remove');
-	    				$asset_path = str_replace(str_finish(url(), '/'), '', $uri);
+                foreach ($matches[0] as $uri)
+                    foreach (Config::get('simplecdn::rules') as $group)
+                        if (@$group['enabled'] && preg_match('/\.(' . @$group['pattern'] . ')(?:[\?\#].*)?$/i', $uri, $matchess))
+                        {
+                            $config_url = Config::get('simplecdn::url');
+                            $config_remove = Config::get('simplecdn::remove');
+                            $asset_path = str_replace(str_finish(url(), '/'), '', $uri);
 
-	    				if (isset($group['url']))
-	    					$config_url = $group['url'];
+                            if (isset($group['url']))
+                                $config_url = $group['url'];
 
-	    				if (isset($group['remove']))
-	    					$config_remove = $group['remove'];
+                            if (isset($group['remove']))
+                                $config_remove = $group['remove'];
 
-	    				if ($config_remove)
-	    					$asset_path = str_replace(str_finish($config_remove, '/'), '', $asset_path);
+                            if ($config_remove)
+                                $asset_path = str_replace(str_finish($config_remove, '/'), '', $asset_path);
 
-	    				$cdn_url = is_array($config_url) ? $config_url[array_rand($config_url)] : $config_url;
-						$output = str_replace($uri, str_finish($cdn_url, '/') . $asset_path, $output);
-	    			}
+                            $cdn_url = is_array($config_url) ? $config_url[array_rand($config_url)] : $config_url;
+                            $output = str_replace($uri, str_finish($cdn_url, '/') . $asset_path, $output);
+                        }
 
-	    	$response->setContent($output);
+                $response->setContent($output);
+            }
 	    }
 	}
 });


### PR DESCRIPTION
This ensures matching/replacing is only done in strings, and not when you (for example) return an array/JSON data.
